### PR TITLE
[8.0] [FIX] account_financial_report_webkit: overlapping headers

### DIFF
--- a/account_financial_report_webkit/report/templates/account_report_general_ledger.mako
+++ b/account_financial_report_webkit/report/templates/account_report_general_ledger.mako
@@ -8,6 +8,9 @@
                 overflow: hidden;
                 white-space: nowrap;
             }
+            div {
+                page-break-inside: avoid;
+            }
             ${css}
         </style>
     </head>

--- a/account_financial_report_webkit/report/templates/aged_trial_webkit.mako
+++ b/account_financial_report_webkit/report/templates/aged_trial_webkit.mako
@@ -32,6 +32,9 @@
             .total{
                font-weight:bold;
             }
+            div {
+                page-break-inside: avoid;
+            }
             ${css}
         </style>
     </head>


### PR DESCRIPTION
When spanning multiple pages, those reports split lines and cause overlapping with the header on the next page.

**Before**
![image](https://user-images.githubusercontent.com/5856745/47579258-73805480-d919-11e8-8ac5-962cc2dbab8d.png)

**After**
![image](https://user-images.githubusercontent.com/5856745/47579264-7a0ecc00-d919-11e8-8874-79154b4a0672.png)
